### PR TITLE
autoapprove use workflow_dispatch

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -16,35 +16,15 @@ jobs:
       pull-requests: write
     steps:
     # Currently there is no way to get the pull request number from the event payload in a workflow_run event.
-    # We save it in the test workflow
-    # These first steps extract it.
+    # We save it in the 'test' workflow.
+    # This first step extracts it.
     # More information about it:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
     - name: 'Download PR number'
-      uses: actions/github-script@v3.1.0
+      uses: actions/download-artifact@v3
       with:
-        script: |
-          console.log("Starting to list artifacts");
-          var artifacts = await github.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: context.payload.workflow_run.id,
-          });
-          console.log("Filtering artifacts");
-          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
-            return artifact.name == "pr_number"
-          })[0];
-          console.log("Downloading artifacts");
-          var download = await github.actions.downloadArtifact({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              artifact_id: matchArtifact.id,
-              archive_format: 'zip',
-          });
-          console.log("Writing artifacts to disk");
-          var fs = require('fs');
-          fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+        name: pr_number
     - run: unzip pr.zip
     - name: Get the PR value and set it in the environment
       run: |
@@ -53,3 +33,6 @@ jobs:
     - uses: hmarr/auto-approve-action@v3
       with:
         pull-request-number: ${{ env.PR_NUMBER }}
+    - run: gh workflow run "automerge" -f prNumber=${{ env.PR_NUMBER }}
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,28 +1,17 @@
 name: automerge
 on:
-  pull_request:
-    types:
-      - labeled
-      - unlabeled
-      - synchronize
-      - opened
-      - edited
-      - ready_for_review
-      - reopened
-      - unlocked
-  pull_request_review:
-    types:
-      - submitted
-  check_suite:
-    types:
-      - completed
-  status: {}
+  workflow_dispatch:
+    inputs:
+      prNumber:
+        description: 'PR Number to auto merge'
+        type: number
+        required: true
 jobs:
   automerge:
     runs-on: ubuntu-20.04
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@135f0bdb927d9807b5446f7ca9ecc2c51de03c4a"
+        uses: "pascalgn/automerge-action@v0.15.6"
         # https://github.com/pascalgn/automerge-action#configuration
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -31,3 +20,4 @@ jobs:
           MERGE_METHOD: "rebase"
           MERGE_RETRIES: "3"
           MERGE_RETRY_SLEEP: "90000"
+          PULL_REQUEST: ${{ inputs.prNumber }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     needs: [test]
     runs-on: ubuntu-latest
+    # The PR number is uploaded instead of triggering another workflow directly
+    # because this workflow has no permissions and runs with the least
+    # privileges (This pipeline can be ran by PRs made from forks).
     name: "Save PR number for Auto Approve workflow_run"
     steps:
       - name: Save PR number


### PR DESCRIPTION
Upgrade to pascalgn/automerge-action to v0.15.6
- Why:
  - Comparison of changes [shows](https://github.com/pascalgn/automerge-action/compare/135f0bdb927d9807b5446f7ca9ecc2c51de03c4a...v0.15.6#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R212) (check changes in README.md) that in the latest version of the action you can set the PULL_REQUEST
  - Also, we are leveraging "workflow_dispatch" so we need the latest version because it [supports the event](https://github.com/pascalgn/automerge-action/compare/135f0bdb927d9807b5446f7ca9ecc2c51de03c4a...v0.15.6#diff-3814d8caba69e5fdf3b23eed56ec7d708b8ede5aed6d686ac579421877938ec7R107) (check changes in lib/api.js)

Switch automerge yml to listen for workflow_dispatch.
- Now what happens:
  - Test Workflow -> Auto approve -> Auto merge

Other changes:
- Other clarifications on permissions
- Use download artifact instead of script to download artifact

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our README.md: https://github.com/web-platform-tests/wpt-metadata/blob/master/README.md 
2. Please label this pull request `do not merge yet` upon creation because the auto-merge feature is enabled in this repository. Once your PR is created, do not enable auto-merge on it. If this pull request is finished, feel free to assign foolip/kyleju as reviewers, or we will review and merge them automatically.
